### PR TITLE
docs: document HTTP client and microservice components

### DIFF
--- a/docs/.pages
+++ b/docs/.pages
@@ -3,4 +3,4 @@ nav:
   - essentials
   - controllers
   - Dependency Injection: di
-  - microservices
+  - Microservices: microservices

--- a/docs/essentials/.pages
+++ b/docs/essentials/.pages
@@ -1,0 +1,6 @@
+nav:
+  - controllers.md
+  - data-validation.md
+  - dependency-injection.md
+  - http-client.md
+  - next-steps.md

--- a/docs/essentials/http-client.md
+++ b/docs/essentials/http-client.md
@@ -1,0 +1,81 @@
+# HTTP Client
+
+Ascender Framework includes a lightweight HTTP client built on top of [HTTPX](https://www.python-httpx.org/). The client integrates with the framework's dependency injection system and supports request/response interceptors and reactive streaming.
+
+## Providing a client
+
+```python title="bootstrap.py"
+from ascender.common.http import provideHTTPClient, HTTPClient
+from ascender.core.types import IBootstrap
+
+bootstrap: IBootstrap = {
+    "providers": [
+        provideHTTPClient(base_url="https://api.example.com")
+    ]
+}
+```
+
+The factory registers `HTTPClient` so it can be injected anywhere in the application:
+
+```python title="main_controller.py"
+from ascender.core import Controller, Get
+from ascender.common.http import HTTPClient
+
+@Controller(standalone=True)
+class MainController:
+    def __init__(self, http: HTTPClient):
+        self.http = http
+
+    @Get()
+    async def list_users(self):
+        return await self.http.get(url="/users")
+```
+
+## Typed responses
+
+Responses can be parsed into Pydantic models by passing the expected type:
+
+```python title="usage.py"
+from pydantic import BaseModel
+
+class User(BaseModel):
+    id: int
+    name: str
+
+user = await http.get(User, url="/users/1")
+```
+
+## Interceptors
+
+`provideHTTPClient` accepts interceptors that can modify requests or responses. Interceptors can be async functions or classes extending `Interceptor`.
+
+```python title="interceptors.py"
+from ascender.common.http import provideHTTPClient, Interceptor
+from httpx import Request, Response
+
+class AuthInterceptor(Interceptor):
+    async def handle_request(self, request: Request) -> Request:
+        request.headers["Authorization"] = "Bearer <token>"
+        return request
+
+    async def handle_response(self, response: Response):
+        return response
+
+async def log_request(request: Request) -> Request:
+    print(request.url)
+    return request
+
+providers = [
+    provideHTTPClient(interceptors=[AuthInterceptor, log_request])
+]
+```
+
+## Streaming responses
+
+The `stream` method returns an RxPY `Observable` for consuming streamed data such as server-sent events.
+
+```python title="stream.py"
+stream = http.stream(dict, method="GET", url="/events")
+stream.subscribe(on_next=lambda chunk: print(chunk))
+```
+

--- a/docs/essentials/next-steps.md
+++ b/docs/essentials/next-steps.md
@@ -32,9 +32,25 @@ Now that you have been introduced to main concepts and parts of Ascender Framewo
 
     ---
 
-    Dive deeper into routing in Ascender Framework. 
-    Find out more about Routing Graphs, Routing Node and Routes. 
+    Dive deeper into routing in Ascender Framework.
+    Find out more about Routing Graphs, Routing Node and Routes.
 
     [:octicons-arrow-right-24: Advanced Routing Guide](/routing/overview)
+
+-   :material-api:{ .lg .middle } __HTTP Client__
+
+    ---
+
+    Learn how to make outbound requests with the built-in HTTP client and interceptors.
+
+    [:octicons-arrow-right-24: HTTP Client Guide](/essentials/http-client)
+
+-   :material-lan:{ .lg .middle } __Microservices__
+
+    ---
+
+    Build distributed systems with Ascender's transport-agnostic microservice layer.
+
+    [:octicons-arrow-right-24: Microservices Overview](/microservices/overview)
 
 </div>

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,17 +1,40 @@
 # Welcome to Ascender Framework
 
-For full documentation visit [mkdocs.org](https://www.mkdocs.org).
+Ascender Framework is a powerful, FastAPI-based framework designed to streamline the development of web applications. Inspired by NestJS and other dependency-injection frameworks, it brings a modern architecture to Python projects.
 
-## Commands
+## Documentation
 
-* `mkdocs new [dir-name]` - Create a new project.
-* `mkdocs serve` - Start the live-reloading docs server.
-* `mkdocs build` - Build the documentation site.
-* `mkdocs -h` - Print help message and exit.
+Get started quickly and explore more advanced features:
 
-## Project layout
+- [Getting Started](introduction/installation.md)
+- [Architecture](introduction/overview.md)
+- [Controllers](essentials/controllers.md)
+- [Validators](essentials/data-validation.md)
+- [Modular Design](essentials/dependency-injection.md)
+- [HTTP Client](essentials/http-client.md)
+- [Microservices](microservices/overview.md)
 
-    mkdocs.yml    # The configuration file.
-    docs/
-        index.md  # The documentation homepage.
-        ...       # Other markdown pages, images and other files.
+## Getting Started
+
+Install Ascender Framework (with its CLI) globally:
+
+```bash
+pip install ascender-framework
+```
+
+Initialize a new project:
+
+```bash
+ascender new --name <project-name> --orm-mode <tortoise|sqlalchemy>
+cd <project-name>
+ascender serve
+# or
+ascender run serve
+```
+
+## Project Structure
+
+- `bootstrap.py`: Framework and server configuration.
+- `controllers/`: Controller classes defining endpoints.
+- `start.py`: Application initialization entry point.
+

--- a/docs/microservices/.pages
+++ b/docs/microservices/.pages
@@ -1,0 +1,3 @@
+nav:
+  - overview.md
+  - getting-started.md

--- a/docs/microservices/overview.md
+++ b/docs/microservices/overview.md
@@ -16,6 +16,17 @@ With this module, developers can create highly maintainable, event-driven archit
 
 In addition, data serialization and conversion of [DTO](/essentials/data-validation#defining-dtos), [Response](/essentials/data-validation#defining-responses) models will be handled on Ascender Framework's Microservice module's side.
 
+## Core Components
 
+The microservices package is composed of several helper classes that work together:
+
+- **`provideMicroservices`** – registers transports and optionally exposes `ClientProxy` instances through injection tokens.
+- **`TransportManager`** – boots transports on application startup and wires message or event patterns to the in-memory bus.
+- **`SubscriptionEventBus`** – lightweight event bus that routes messages to handlers and supports wildcard subscriptions.
+- **`ClientProxy`** – high-level API used by services to send messages or emit events using the selected transport.
+
+These pieces allow services to communicate through a transport‑agnostic layer while staying fully integrated with Ascender's dependency injection.
 
 ## Learn more about Ascender Framework's dependency injection
+The microservice module relies on dependency injection. See the [Dependency Injection overview](/di/overview) for details.
+


### PR DESCRIPTION
## Summary
- add dedicated HTTP client guide with usage, interceptors and streaming examples
- extend microservices overview with core components and DI references
- refresh documentation index, navigation and next steps to link to new sections

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68945ab3b174832eadc944c3b1800bb9